### PR TITLE
Feature/648 phone number input

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"i18next": "^19.4.1",
 		"i18next-browser-languagedetector": "^4.0.2",
 		"i18next-react-native-language-detector": "^1.0.2",
+		"libphonenumber-js": "^1.7.50",
 		"metro-config": "^0.58.0",
 		"moment": "^2.24.0",
 		"react": "~16.9.0",

--- a/src/forms/frame.js
+++ b/src/forms/frame.js
@@ -23,16 +23,22 @@ export default function Frame(props) {
 	)
 }
 
-export function useFrameFocus(initialFocus = false) {
+export function useFrameFocus(initialFocus = false, inputProps = {}) {
 	const [focused, setFocus] = useState(initialFocus)
 
 	return {
 		value: focused,
 		props: {
 			onFocus: function () {
+				if (typeof inputProps.onFocus === "function") {
+					inputProps.onFocus()
+				}
 				setFocus(true)
 			},
 			onBlur: function () {
+				if (typeof inputProps.onBlur === "function") {
+					inputProps.onBlur()
+				}
 				setFocus(false)
 			},
 		},

--- a/src/forms/phone-number.js
+++ b/src/forms/phone-number.js
@@ -1,0 +1,27 @@
+import React from "react"
+import TextField from "./text"
+import { parsePhoneNumberFromString } from "libphonenumber-js"
+
+export function PhoneNumberField(props) {
+	const { value, onChangeText, ...nextProps } = props
+	function handleOnBlur() {
+		const phoneNumber = parsePhoneNumberFromString(value, "CA")
+		onChangeText(phoneNumber ? phoneNumber.formatNational() : "")
+	}
+	return (
+		<TextField
+			keyboardType="phone-pad"
+			textContentType="telephoneNumber"
+			autocompletetype="tel"
+			value={value}
+			onChangeText={onChangeText}
+			onBlur={handleOnBlur}
+			{...nextProps}
+		/>
+	)
+}
+
+export function getStandardPhoneNumber(inputValue) {
+	const phoneNumber = parsePhoneNumberFromString(inputValue, "CA")
+	return phoneNumber ? phoneNumber.number : ""
+}

--- a/src/forms/text.js
+++ b/src/forms/text.js
@@ -6,7 +6,7 @@ import FormStyles from "../styles/forms"
 
 function FramedTextField(props) {
 	const { error, ...inputProps } = props
-	const focused = useFrameFocus()
+	const focused = useFrameFocus(false, inputProps)
 
 	return (
 		<Frame focused={focused.value} error={error}>

--- a/src/pages/test/forms.js
+++ b/src/pages/test/forms.js
@@ -21,6 +21,7 @@ import ArtistSelectDropdown from "../../smartsplit/artist/select"
 import AuthModal from "../auth/modal"
 import { SearchAndTag } from "../../forms/search-and-tag"
 import { Tag } from "../../widgets/tag"
+import { getPhoneNumber, PhoneNumberField } from "../../forms/phone-number"
 
 export default function FormsTest() {
 	return (
@@ -137,6 +138,7 @@ function TestText() {
 }
 
 function TestBasicFields() {
+	const [phoneNumber, setPhoneNumber] = useState("")
 	return (
 		<Column of="component">
 			<Row of="component">
@@ -163,6 +165,15 @@ function TestBasicFields() {
 				defaultValue="test@smartsplit.org"
 				placeholder="courriel"
 			/>
+			<Row of="component">
+				<PhoneNumberField
+					value={phoneNumber}
+					onChangeText={setPhoneNumber}
+					label="Numéro de téléphone"
+					label_hint="Optionnel"
+					placeholder="Numero de tel"
+				/>
+			</Row>
 		</Column>
 	)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7920,6 +7920,14 @@ levenary@^1.1.1:
   dependencies:
     leven "^3.1.0"
 
+libphonenumber-js@^1.7.50:
+  version "1.7.50"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.7.50.tgz#4e08663e3868aadc4a6145fba1d0344ec0e820ae"
+  integrity sha512-FmdA2WvwdTgu1X05zBnAE+3UAA09o3hFxEaqR0J+x7tGPAt1AD7Dj54L58PTJodrFBve/AIThFtC/UGqfSLbBw==
+  dependencies:
+    minimist "^1.2.5"
+    xml2js "^0.4.17"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -13702,7 +13710,7 @@ xml-parse-from-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
 
-xml2js@^0.4.23, xml2js@^0.4.5:
+xml2js@^0.4.17, xml2js@^0.4.23, xml2js@^0.4.5:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==


### PR DESCRIPTION
**EDIT 27-04-2020** L'input essaie de parser et formater le numéro uniquement au onBlur. Si libphone parvient à parser un numero, il est affiché en format national (CA par défaut pour le moment). Sinon l'input est reset et affiche le placeholder. L'input supporte toutes les nationalités donc si le numero entrée est +33612345678 il sera affiché 06 12 34 56 78 qui est le format national francais.
 
Pour récupérer le numéro à stocker dans la bd au format international, il faut utiliser le helper `getStandardPhoneNumber` qui parse le numero entré et retourne le numero au format international (+15141234567, +33612345678 etc) ou une string vide si la value passée est pas parsable
**EDIT 27-04-2020** 

Basé sur le <TextField> existant, ajoute seulement les placeholders, formattage et validation.
Supporte uniquement que les numéros canadien, il faudra ajouter le support des autres pays plus tard (peur de manquer de temps pour le reste du sprint, j'ai déjà passé 5h sur cette fonctionnalité). La valeur du champ dans l'état du formulaire parent est formatté en numéro international avec le préfixe +1. Les entrées de l'utilisateur sont filtrées pour laisser passer que les numéro et on ne peut commencer un numéro de telephone par + ou 1.

![image](https://user-images.githubusercontent.com/17026717/80146529-fa020a80-857f-11ea-9e41-732896f55b04.png)
 