### PR TITLE
916 - Copyright manual split

### DIFF
--- a/src/forms/checkbox.js
+++ b/src/forms/checkbox.js
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import { TouchableWithoutFeedback } from "react-native"
 import { Svg, Rect, Path } from "react-native-svg"
 
-import { Column, forEachChildren, Row } from "../layout"
+import { Column, Row } from "../layout"
 import { Text } from "../text"
 import { Colors, Metrics } from "../theme"
 import FormStyles from "../styles/forms"

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { View, StyleSheet } from "react-native"
+import { View } from "react-native"
 import MetricsStyles from "./styles/metrics"
 import LayoutStyles from "./styles/layout"
 import LayerStyles from "./styles/layers"

--- a/src/mobX/states/SplitsPagesState.js
+++ b/src/mobX/states/SplitsPagesState.js
@@ -14,7 +14,7 @@ class CopyrightState {
 		this.shares = shares
 
 		/**
-		 * reaction that perform roles checking upon
+		 * reaction that performs roles checking upon
 		 * mode change to or from equal
 		 */
 		reaction(
@@ -30,7 +30,7 @@ class CopyrightState {
 		)
 
 		/**
-		 * Reaction that reset this.equalModeInitiated when
+		 * Reaction that resets this.equalModeInitiated when
 		 * adding or removing a shareholder
 		 */
 		reaction(
@@ -58,8 +58,33 @@ class CopyrightState {
 		})
 	}
 
-	@computed get sharesValues() {
-		return this.shares.map((share) => share.toJS())
+	@action updateShare(index, value) {
+		const diff = value - this.shares[index].toJS().shares
+		console.log("DIFFF", diff)
+		this.shares.forEach((share, i) => {
+			if (i === index) {
+				share.setValue(value)
+			} else {
+				share.setValue(share.toJS().shares - diff)
+			}
+		})
+	}
+
+	@computed get sharesPercents() {
+		return new Map(
+			this.shares.map((share) => [
+				share.shareHolderId,
+				share.shares.value > 0
+					? (100 * share.shares.value) / this.sharesTotal
+					: 0,
+			])
+		)
+	}
+
+	@computed get sharesTotal() {
+		return this.shares
+			.map((share) => share.toJS().shares)
+			.reduce((a, n) => a + n, 0)
 	}
 
 	@computed get chartProps() {

--- a/src/pages/user/settings.js
+++ b/src/pages/user/settings.js
@@ -86,7 +86,7 @@ export function SettingsPageFull() {
 	const { t } = useTranslation()
 	const history = useHistory()
 	//const form = useForm()
-  const settings = useStorePath('settings')
+	const settings = useStorePath("settings")
 	return (
 		<SubScreenLayout
 			title={<SettingsPageTitle />}
@@ -95,9 +95,9 @@ export function SettingsPageFull() {
 				<Button
 					tertiary
 					text={t("general:buttons.save")}
-					onClick={async() => {
+					onClick={async () => {
 						//console.log('saving the profile data')
-          await settings.saveProfile()
+						await settings.saveProfile()
 					}}
 				/>
 			}

--- a/src/smartsplit/components/manual-share.js
+++ b/src/smartsplit/components/manual-share.js
@@ -1,0 +1,24 @@
+import React, { useState } from "react"
+import { observer } from "mobx-react"
+import { observable } from "mobx"
+import Slider from "../../widgets/slider"
+import { formatPercentage } from "../../utils/utils"
+import { Text } from "../../text"
+
+const ManualShare = observer((value, onChange, ...nextProps) => {
+	const [displayValue] = useState(() => observable.box(value))
+
+	return (
+		<>
+			<Slider
+				value={value}
+				onChange={(value) => displayValue.set(value)}
+				{...nextProps}
+				onRelease={onChange}
+			/>
+			<Text bold>{formatPercentage(displayValue, 1)}</Text>
+		</>
+	)
+})
+
+export default ManualShare

--- a/src/smartsplit/components/share-card.js
+++ b/src/smartsplit/components/share-card.js
@@ -1,12 +1,10 @@
 import React from "react"
 import { Column, Hairline, Row, Spacer } from "../../layout"
 import { Colors } from "../../theme"
-import HelpCircleFull from "../../svg/help-circle-full"
 import UserAvatar from "../user/avatar"
 import { Text } from "../../text"
-import ProgressBar from "../../widgets/progress-bar"
 import { TouchableWithoutFeedback, View, StyleSheet } from "react-native"
-import { formatPercentage, getFullName } from "../../utils/utils"
+import { getFullName } from "../../utils/utils"
 import { CardStyles } from "../../widgets/card"
 import { useTranslation } from "react-i18next"
 import XIcon from "../../svg/x"
@@ -31,13 +29,11 @@ const styles = StyleSheet.create({
 const ShareCard = observer(
 	({
 		shareHolderId,
-		sharePercent,
-		tip,
 		children,
 		actions,
-		color,
 		error,
 		onClose,
+		bottomAction,
 		...nextProps
 	}) => {
 		const { t } = useTranslation()
@@ -50,7 +46,6 @@ const ShareCard = observer(
 
 		isAuthUser && addStyle("frame_yourself")
 		error && addStyle("frame_error")
-		color = color || Colors.action
 		return (
 			<>
 				<Row
@@ -61,11 +56,7 @@ const ShareCard = observer(
 				>
 					<Column valign="spread" align="center">
 						<UserAvatar size="small" user={userData} />
-						<TouchableWithoutFeedback>
-							<View>
-								<HelpCircleFull />
-							</View>
-						</TouchableWithoutFeedback>
+						{bottomAction}
 					</Column>
 					<Column flex={1} of="component">
 						<Row align="spread">
@@ -86,15 +77,6 @@ const ShareCard = observer(
 						</Row>
 						<Hairline />
 						{children}
-						<Row of="component" valign="center">
-							<ProgressBar
-								progress={sharePercent}
-								size="xsmall"
-								style={{ flex: 1 }}
-								color={color}
-							/>
-							<Text bold>{formatPercentage(sharePercent, 1)}</Text>
-						</Row>
 					</Column>
 				</Row>
 				<Spacer of="inside" />

--- a/src/smartsplit/components/split-chart.js
+++ b/src/smartsplit/components/split-chart.js
@@ -164,7 +164,6 @@ function useTooltips(data, slices, center) {
 	const [tooltipData, setTooltipData] = useState(TooltipInitialState)
 	const centerVectors = generateShareCenterVectors(slices, center)
 	function handleFocus(key) {
-		console.log(data)
 		const shareHolder = data.filter((shareHolder) => shareHolder.key === key)[0]
 		setTooltipData({
 			vector: centerVectors.get(key),

--- a/src/svg/lock.js
+++ b/src/svg/lock.js
@@ -20,11 +20,11 @@ export default function LockIcon(props) {
 				strokeLinejoin="round"
 			/>
 			<Path
-				d="M7 11V7.00003C6.99876 5.76008 7.45828 4.5639 8.28938 3.6437C9.12047 2.7235 10.2638 2.14493 11.4975 2.02032C12.7312 1.89571 13.9671 2.23393 14.9655 2.96934"
+				d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11"
 				stroke={color}
 				strokeWidth="2"
 				strokeLinecap="round"
-				strokeLinejoin="round"
+				stroke-linejoin="round"
 			/>
 		</Svg>
 	)

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -48,7 +48,7 @@ export function useDimensions() {
 	return [ref, dimensions]
 }
 
-export function useInterpolator([min0, max0], [min1, max1]) {
+export function useInterpolators([min0, max0], [min1, max1]) {
 	const range0 = max0 - min0
 	const range1 = max1 - min1
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,5 +1,4 @@
 import React from "react"
-import { Text } from "../text"
 import { Metrics } from "../theme"
 
 export const Origin = {
@@ -81,7 +80,7 @@ export function highlightMatchedStrings(str, pattern) {
 	return [...splits]
 		.map((el, index) => {
 			if (index < splits.length - 1) {
-				return [el, <b>{matchs[index]}</b>]
+				return [el, <b key={index}>{matchs[index]}</b>]
 			} else if (el !== "") {
 				return [el]
 			}


### PR DESCRIPTION
* Added lock icon (svg/lock.js),
* Added unlock icon (src/svg/unlock.js)
* Slider fix of interpolators initialization
* Fix: Slider interpolators not updating
* Share card refactor
* Split mode integration with share card UI wip
* Fixed adding shareholder to a split if he's not already in the split
* Fixed checkbox selection with Field value
* Replaced sharesValues to sharesTotal directly in SplitsPagesState
* Added ManualShare component to abstract Slider changes and percentage
  change
* Fixed Slider Progress bar rendering
* Added new computed value sharesPercents. It's a generated
  [shareholderId, sharepercent] Map each time split shares are modified
* Modified Copyright split page to use SharesPercents instead of
  computing share percent manually
* Introduced a step value in slider to implement a dp buffer that will
  prevent too many rerender for too small handle move
* Fix too much rendering by setting a step and using it as a modulo of
  accumulated distance since touch started
* Added percentage displayed XX.XX%