### PR TITLE
1001 - shares computing middleware for performance split

### DIFF
--- a/src/forms/select.js
+++ b/src/forms/select.js
@@ -1,10 +1,28 @@
 import React from "react"
 import { View, ScrollView, TouchableWithoutFeedback } from "react-native"
 import Dropdown from "./dropdown"
-import { Column, Hairline } from "../layout"
+import { Column } from "../layout"
 import { Text } from "../text"
 import FormStyles from "../styles/forms"
 
+/**
+ *	Select form input component. Let user make a choice in props.options
+ *	props: {
+ *		value
+ *		onChange
+ *		placeholder
+ *		initialValue
+ *		options: Array<{
+ *					- key: the actual string used as the select input value
+ *					- value: displayed value associated with the key when Select's dropdown
+ *					is opened
+ *					- displayValue (optional): situational property useful when
+ *					value is a component we don't want to use as Select's placeholder.
+ *					Can be a string or a component
+ *				}>
+ *		children
+ *	}
+ **/
 export default class Select extends React.PureComponent {
 	static defaultProps = {
 		options: [],
@@ -29,9 +47,14 @@ export default class Select extends React.PureComponent {
 			(o) => o.key === selectedValue
 		)
 
-		const value = selectedOption ? selectedOption.value : this.props.placeholder
+		let value
+		if (!!selectedOption && !!selectedOption.displayValue) {
+			value = selectedOption.displayValue
+		} else {
+			value = selectedOption ? selectedOption.value : this.props.placeholder
+		}
 
-		if (typeof value === "string")
+		if (typeof value === "string" || typeof value === "function")
 			return <Text style={{ flex: 1 }}>{value}</Text>
 		else return value
 	}
@@ -100,7 +123,7 @@ export function SelectItem(props) {
 					selected && FormStyles.select_item_selected,
 				]}
 			>
-				{typeof value === "string" ? <Text>{value}</Text> : { value }}
+				{typeof value === "string" ? <Text>{value}</Text> : value}
 			</View>
 		</TouchableWithoutFeedback>
 	)

--- a/src/mobX/hooks.js
+++ b/src/mobX/hooks.js
@@ -12,9 +12,9 @@ export function useAuthUser() {
 	return auth.user
 }
 
-export function useSplitsPagesState() {
+export function useSplitsPagesState(type) {
 	const { splitsPages } = useStores()
-	return splitsPages
+	return type ? splitsPages[type] : splitsPages
 }
 
 export function useDocsModel(workpieceId, type) {

--- a/src/mobX/models/workpieces/rights-splits/PerformanceSplitModel.js
+++ b/src/mobX/models/workpieces/rights-splits/PerformanceSplitModel.js
@@ -15,9 +15,9 @@ export default class PerformanceSplitModel extends RightSplitModel {
  *	values
  **/
 export const initData = {
-	shares: 1,
+	shares: 0,
 	roles: [],
-	status: "",
+	status: null,
 	comment: "",
 	vote: "undecided",
 }

--- a/src/mobX/states/UIStates/RightsSplitsPages/CopyrightSplit.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/CopyrightSplit.js
@@ -17,8 +17,8 @@ export default class CopyrightSplit extends SplitPageState {
 	 *	Action to initialize the ui state. Shares are an array
 	 *	of shareholders stripped values from their observables
 	 **/
-	@action init(pageTitle, titleLeft, titleRight, shares) {
-		super.init(pageTitle, shares)
+	@action init(domainState, pageTitle, titleLeft, titleRight) {
+		super.init(domainState, pageTitle)
 		// Titles of Dual pie chart halfs
 		this.titleLeft = titleLeft
 		this.titleRight = titleRight

--- a/src/mobX/states/UIStates/RightsSplitsPages/PerformanceSplit.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/PerformanceSplit.js
@@ -14,13 +14,23 @@ export default class PerformanceSplit extends SplitPageState {
 	form = PerformanceForm
 	@computed get sharesData() {
 		return this.shares.map((share) => {
+			const sharesQty =
+				this.domainState.majorShares.length +
+				this.domainState.minorShares.length
 			return {
 				id: share.shareHolderId,
 				shares: share.shares,
 				roles: share.roles,
 				status: share.status,
-				percent: share.shares > 0 ? (100 * share.shares) / this.sharesTotal : 0,
+				percent: share.shares > 0 ? (100 * share.shares) / sharesQty : 0,
 			}
 		})
+	}
+
+	genChartProps() {
+		return super.genChartProps([
+			...this.domainState.majorShares,
+			...this.domainState.minorShares,
+		])
 	}
 }

--- a/src/mobX/states/UIStates/RightsSplitsPages/SplitPageState.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/SplitPageState.js
@@ -6,30 +6,21 @@ import { Colors } from "../../../../theme"
  *	states derive from it
  **/
 export default class SplitPageState {
-	/**
-	 *	Action to initialize the ui state. Shares are an array
-	 *	of shareholders stripped values from their observables
-	 *	Split page states can't be initialized upon RootStore
-	 *	creation like other stores because a workpiece has not
-	 *	been selected yet by the user
-	 **/
-	@action init(pageTitle, shares) {
-		this.shares = shares
+	@action init(domainState, pageTitle) {
+		this.domainState = domainState
 		this.pageTitle = pageTitle
 	}
 
 	constructor(logo) {
 		this.logo = logo
 	}
-
+	@observable domainState
 	pageTitle
 	progress
 	logo
 	@observable chartSize = 0
-	@observable shares
-
-	@computed get sharesTotal() {
-		return this.shares.map((share) => share.shares).reduce((a, n) => a + n, 0)
+	@computed get shares() {
+		return this.domainState.sharesValues
 	}
 
 	shareColors = Object.values(Colors.secondaries)
@@ -38,8 +29,9 @@ export default class SplitPageState {
 		return this.shareColors[index % this.shareColors.length]
 	}
 
-	sharesToChartData() {
-		return this.shares.map((share, i) => ({
+	sharesToChartData(shares = null) {
+		shares = shares ? shares : this.shares
+		return shares.map((share, i) => ({
 			key: share.shareHolderId,
 			name: share.shareHolderId,
 			share: share.shares,
@@ -47,11 +39,15 @@ export default class SplitPageState {
 		}))
 	}
 
-	genChartProps() {
+	genChartProps(shares = null) {
 		return {
-			data: this.sharesToChartData(),
+			data: this.sharesToChartData(shares),
 			size: this.chartSize,
 			logo: this.logo,
 		}
+	}
+
+	@computed get sharesTotal() {
+		return this.shares.length
 	}
 }

--- a/src/mobX/states/UIStates/RightsSplitsPages/SplitsPagesState.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/SplitsPagesState.js
@@ -1,8 +1,7 @@
-import BaseState from "../../../BaseState"
 import CopyrightSplit from "./CopyrightSplit"
 import PerformanceSplit from "./PerformanceSplit"
 
-export default class SplitsPagesState extends BaseState {
+export default class SplitsPagesState {
 	copyright = new CopyrightSplit()
 	performance = new PerformanceSplit()
 }

--- a/src/mobX/states/WorkpieceStates/SplitStates/CopyrightSplit.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/CopyrightSplit.js
@@ -12,7 +12,7 @@ export default class CopyrightSplit extends SplitState {
 		/**
 		 * reaction that performs roles checking upon
 		 * mode change to or from "equal"
-		 */
+		 **/
 		reaction(
 			() => this.mode,
 			(mode) => {
@@ -83,7 +83,7 @@ export default class CopyrightSplit extends SplitState {
 				try {
 					smallestShare = shares[0].toJS()
 				} catch (e) {
-					console.error("Error with smallest share", e, shares, this.allShares)
+					console.error("Error with smallest share", e, shares)
 				}
 
 				// 3. Try an equal split of toSplit

--- a/src/mobX/states/WorkpieceStates/SplitStates/PerformanceSplit.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/PerformanceSplit.js
@@ -1,6 +1,6 @@
 import SplitState from "./SplitState"
 import PerformanceSplitModel from "../../../models/workpieces/rights-splits/PerformanceSplitModel"
-import { observable } from "mobx"
+import { action, computed, reaction } from "mobx"
 
 /**
  *	Performance split domain state derived from SplitState.
@@ -9,7 +9,62 @@ import { observable } from "mobx"
 export default class PerformanceSplit extends SplitState {
 	constructor(shares) {
 		super(shares, PerformanceSplitModel)
+		reaction(
+			() => this.shareHolders.size,
+			() => this.updateShares()
+		)
 	}
-	@observable mode = "equal"
+
 	statusValues = ["principal", "featured", "bandMember", "session"]
+
+	@computed get majorShares() {
+		return this.sharesValues.filter(
+			(share) => share.status && share.status !== "session"
+		)
+	}
+
+	@computed get minorShares() {
+		return this.sharesValues.filter(
+			(share) => share.status && share.status === "session"
+		)
+	}
+
+	@computed get mode() {
+		if (
+			(this.majorShares.length > 0 && this.minorShares.length === 0) ||
+			(this.majorShares.length === 0 && this.minorShares.length > 0)
+		) {
+			return "equal"
+		} else if (this.majorShares.length > 0 && this.minorShares.length > 0) {
+			return "80-20"
+		} else {
+			return null
+		}
+	}
+
+	@action setShareStatus(id, status) {
+		this.updateShareField(id, "status", status)
+		this.updateShares()
+	}
+
+	@action updateShares() {
+		if (this.mode === "equal") {
+			this.setShares(
+				this.minorShares.length === 0 ? this.majorShares : this.minorShares
+			)
+			this.setShares(
+				this.minorShares.length === 0 ? this.minorShares : this.majorShares,
+				0
+			)
+		} else if (this.mode === "80-20") {
+			this.setShares(
+				this.majorShares,
+				(0.8 * this.shareHolders.size) / this.majorShares.length
+			)
+			this.setShares(
+				this.minorShares,
+				(0.2 * this.shareHolders.size) / this.minorShares.length
+			)
+		}
+	}
 }

--- a/src/mobX/states/WorkpieceStates/SplitStates/SplitState.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/SplitState.js
@@ -12,7 +12,7 @@ export default class SplitState {
 	@observable shareHolders = new Map()
 
 	/**
-	 * @return: Array<{Field.value}>
+	 * 	@return: Array<{Field.value}>
 	 **/
 	@computed get sharesValues() {
 		return [...this.shareHolders.values()].map((share) => share.toJS())
@@ -83,6 +83,21 @@ export default class SplitState {
 			}
 		})
 	}
+
+	/**
+	 *	Update all shares if no shares array are provided.
+	 *	args:
+	 *	- Array<ShareValues>: ShareValues must
+	 *	be an object with a valid shareHolderId key
+	 *	- value: Value to update shares with. Default
+	 *	to 1
+	 **/
+	@action setShares(shares = this.sharesValues, value = 1) {
+		shares.forEach((share) => {
+			this.shareHolders.get(share.shareHolderId).setValue("shares", value)
+		})
+	}
+
 	addShare(share) {
 		return this.addRightHolder(share.shareHolderId, share)
 	}

--- a/src/pages/workpieces/index.js
+++ b/src/pages/workpieces/index.js
@@ -28,10 +28,10 @@ import { DocumentYourWork, ProtectYourWork, ShareYourCopyright } from "./cards"
 import { useStorePath, useStores } from "../../mobX"
 import { observer } from "mobx-react"
 import DocumentationPage from "./documentation"
-
 const WorkpiecesRouter = observer(() => {
 	const match = useRouteMatch("/workpieces/:workpiece_id")
 	const workpiece = useStorePath("workpieces").fetch(match.params.workpiece_id)
+
 	return (
 		<WorkpieceContext.Provider value={workpiece}>
 			<Switch>

--- a/src/pages/workpieces/rights-splits/copyright.js
+++ b/src/pages/workpieces/rights-splits/copyright.js
@@ -19,29 +19,28 @@ import { useTranslation } from "react-i18next"
 import { observer } from "mobx-react"
 import { useRightsSplits } from "../context"
 import { initData } from "../../../mobX/models/workpieces/rights-splits/CopyrightSplitModel"
-import { useSplitsPagesState } from "../../../mobX/hooks"
 import ProgressBar from "../../../widgets/progress-bar"
 import { formatPercentage } from "../../../utils/utils"
 import Slider from "../../../widgets/slider"
 import { runInAction } from "mobx"
 import PercentageInput from "../../../forms/percentage"
+import { useSplitsPagesState } from "../../../mobX/hooks"
+
 const CopyrightForm = observer(() => {
 	const copyrightSplit = useRightsSplits("copyright")
-	const pageState = useSplitsPagesState().copyright
+	const pageState = useSplitsPagesState("copyright")
 	const { sharesData, sharesTotal } = pageState
 	const { t } = useTranslation("rightsSplits")
-
 	function addShareHolder(id) {
 		if (id && !copyrightSplit.shareHolders.has(id)) {
 			copyrightSplit.addRightHolder(id, initData)
 		}
 	}
-
 	//FOR TESTING PURPOSE
-	React.useEffect(() => {
-		addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
-		addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
-	}, [])
+	// React.useEffect(() => {
+	// 	addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
+	// 	addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
+	// }, [])
 
 	function renderShareCards() {
 		return sharesData.map((share, i) => (

--- a/src/pages/workpieces/rights-splits/index.js
+++ b/src/pages/workpieces/rights-splits/index.js
@@ -10,7 +10,6 @@ import { observer } from "mobx-react"
 import { useTranslation } from "react-i18next"
 import { useCurrentWorkpiece } from "../context"
 import { useSplitsPagesState } from "../../../mobX/hooks"
-import { useRightsSplits } from "../context"
 
 /**
  *	Split forms wrapper
@@ -30,18 +29,18 @@ const RightsSplitsPage = observer(() => {
 		)
 	const workpiece = useCurrentWorkpiece()
 
-	// Initialization of split UI States with current workpiece splits
-	const splits = useRightsSplits()
+	// Loading translation to UIStates. Surely there is
+	// a better way to do that :-)
 	const splitUIStates = useSplitsPagesState()
 	splitUIStates.copyright.init(
+		workpiece.rightsSplits.copyright,
 		t("copyright.title"),
 		t("lyrics"),
-		t("music"),
-		splits.copyright.sharesValues
+		t("music")
 	)
 	splitUIStates.performance.init(
-		t("performance.title"),
-		splits.performance.sharesValues
+		workpiece.rightsSplits.performance,
+		t("performance.title")
 	)
 
 	const { workpieces } = useStores()

--- a/src/pages/workpieces/rights-splits/performance.js
+++ b/src/pages/workpieces/rights-splits/performance.js
@@ -15,10 +15,22 @@ import { useSplitsPagesState } from "../../../mobX/hooks"
 import { initData } from "../../../mobX/models/workpieces/rights-splits/PerformanceSplitModel"
 import ProgressBar from "../../../widgets/progress-bar"
 import { formatPercentage } from "../../../utils/utils"
+import { StyleSheet } from "react-native"
+import { runInAction } from "mobx"
+
+const Styles = StyleSheet.create({
+	checkboxesContainer: {
+		borderLeftWidth: 2,
+		borderLeftColor: Colors.stroke,
+		paddingLeft: Metrics.spacing.component,
+	},
+	selectFrame: {
+		backgroundColor: Colors.primary_reversed,
+	},
+})
 
 const PerformanceForm = observer(() => {
 	const performanceSplit = useRightsSplits("performance")
-	console.log("PERFORMANCE SPLIT", performanceSplit)
 	const pageState = useSplitsPagesState().performance
 	const { t } = useTranslation("rightsSplits")
 
@@ -29,10 +41,10 @@ const PerformanceForm = observer(() => {
 	}
 
 	//FOR TESTING PURPOSE
-	React.useEffect(() => {
-		addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
-		addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
-	}, [])
+	// React.useEffect(() => {
+	// 	addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
+	// 	addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
+	// }, [])
 	function genSelectOptions() {
 		return performanceSplit.statusValues.map((status) => {
 			return {
@@ -43,6 +55,7 @@ const PerformanceForm = observer(() => {
 						<Text secondary>{t(`performance.artistStatusDef.${status}`)}</Text>
 					</>
 				),
+				displayValue: t(`performance.artistStatuses.${status}`),
 			}
 		})
 	}
@@ -59,9 +72,8 @@ const PerformanceForm = observer(() => {
 					placeholder={t("status")}
 					options={genSelectOptions()}
 					value={share.status}
-					onChange={(value) =>
-						performanceSplit.updateShareField(share.id, "status", value)
-					}
+					onChange={(value) => performanceSplit.setShareStatus(share.id, value)}
+					style={Styles.selectFrame}
 				/>
 				<CheckBoxGroup
 					selection={share.roles}
@@ -69,10 +81,15 @@ const PerformanceForm = observer(() => {
 						performanceSplit.updateShareField(share.id, "roles", roles)
 					}
 				>
-					<Column of="component">
-						<CheckBoxGroupButton value="singer" label={t("roles.singer")} />
-						<CheckBoxGroupButton value="musician" label={t("roles.musician")} />
-					</Column>
+					<Row style={Styles.checkboxesContainer}>
+						<Column of="component">
+							<CheckBoxGroupButton value="singer" label={t("roles.singer")} />
+							<CheckBoxGroupButton
+								value="musician"
+								label={t("roles.musician")}
+							/>
+						</Column>
+					</Row>
 				</CheckBoxGroup>
 				<Row of="component" valign="center">
 					<ProgressBar
@@ -119,9 +136,11 @@ const PerformanceForm = observer(() => {
 			<Column
 				flex={1}
 				align="center"
-				onLayout={(e) => (pageState.chartSize = e.nativeEvent.layout.width)}
+				onLayout={(e) =>
+					runInAction(() => (pageState.chartSize = e.nativeEvent.layout.width))
+				}
 			>
-				<SplitChart {...pageState.genChartProps()} />
+				{performanceSplit.mode && <SplitChart {...pageState.genChartProps()} />}
 			</Column>
 		</Row>
 	)

--- a/src/widgets/dropdown.js
+++ b/src/widgets/dropdown.js
@@ -12,6 +12,7 @@ import { Overlay } from "./scrollable"
 
 import ChevronDown from "../svg/chevron-down"
 import ArrowUp from "../svg/chevron-up"
+import { Colors } from "../theme"
 
 /**
  * Un menu dropdown simple: un placeholder, une flèche. Lorsqu'on clique dessus, son contenu (children) est alors affiché dans un dropdown en dessous de l'élément.
@@ -118,7 +119,11 @@ export class Dropdown extends React.Component {
 		}
 
 		return (
-			<View ref={this.frame} onLayout={this.onLayout} style={{ flex: 1 }}>
+			<View
+				ref={this.frame}
+				onLayout={this.onLayout}
+				style={[{ flex: 1 }, this.props.style]}
+			>
 				<DropdownRow
 					noFocusToggle={this.props.noFocusToggle}
 					noPressToggle={this.props.noPressToggle}

--- a/src/widgets/slider.js
+++ b/src/widgets/slider.js
@@ -142,7 +142,7 @@ const Slider = observer(
 
 			// Trigger onChange only when accumulated distance is
 			// around a multiple of dpStep
-			if (Math.abs(gestureState.dx % dpStep) < 0.1) {
+			if (Math.abs(gestureState.dx % dpStep) < 0.5) {
 				onChange(dpToValue(position))
 			}
 		}

--- a/translations/en.js
+++ b/translations/en.js
@@ -501,16 +501,20 @@ export const rightsSplits = {
 			<>
 				Seperate here the <b>neighbor right</b> between <b>performers</b>,
 				whether musicians or singers. <i>Group</i> members share this right with
-				equal splits. <i>Main artists</i> and <i>guest artists</i> share 30%,
+				equal splits. <i>Main artists</i> and <i>guest artists</i> share 80%,
 				while the remaining 20% is split among <i>featured artists</i>, if
 				applicable.
 			</>
 		),
 		artistStatuses: {
-			principal: "Artiste principal",
-			featured: "Artiste invité",
-			bandMember: "Membre du groupe",
-			session: "Artiste accompagnateur",
+			principal: "Main artist",
+			featured: () => (
+				<>
+					Starred Artist (<i>featuring</i>)
+				</>
+			),
+			bandMember: "Band member",
+			session: "Accompanying artist",
 		},
 		artistStatusDef: {
 			principal: 'Also called "Starred Artist" or "Solo Artist"',

--- a/translations/fr.js
+++ b/translations/fr.js
@@ -500,7 +500,7 @@ export const rightsSplits = {
 				On sépare ici le <b>droit</b> voisin entre les <b>interprètes</b>,
 				autant les musiciens que les chanteurs. Les membres d'un <i>groupe</i>{" "}
 				se partagent ce droit à parts égales. Les <i>artistes principaux</i> et{" "}
-				<i>artistes invités</i> se partagent 30%, tantdis que les 20% restant
+				<i>artistes invités</i> se partagent 80%, tantdis que les 20% restant
 				est partagé parmi les <i>artistes accompagnateurts</i>, le cas échéant.
 			</>
 		),


### PR DESCRIPTION
* Fixed select value rendering when passing a component instead of a
  string
* Added hairline left side of checkboxes
* Added new key displayValue to Select options. It overrides value key
  as placeholder for Select component
* Added style prop to Select
* Added domainState property to split pages states to get specific
  properties
* 80-20 middleware implementation
* Performance split UI state: override of genChartProp to exclude from
  chart shareholders without shares and percentages computations