### PR TITLE
942 sticky pie chart (and split pages rendering fixes)

### DIFF
--- a/src/mobX/states/UIStates/RightsSplitsPages/PerformanceSplit.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/PerformanceSplit.js
@@ -2,6 +2,7 @@ import CircledStar from "../../../../svg/circled-star"
 import { computed } from "mobx"
 import SplitPageState from "./SplitPageState"
 import PerformanceForm from "../../../../pages/workpieces/rights-splits/performance"
+import { Colors, Metrics } from "../../../../theme"
 
 /**
  *  Performance form page UI state
@@ -25,6 +26,20 @@ export default class PerformanceSplit extends SplitPageState {
 				percent: share.shares > 0 ? (100 * share.shares) / sharesQty : 0,
 			}
 		})
+	}
+
+	getStyles(windowWidth) {
+		return {
+			...super.getStyles(windowWidth),
+			checkboxesContainer: {
+				borderLeftWidth: 2,
+				borderLeftColor: Colors.stroke,
+				paddingLeft: Metrics.spacing.component,
+			},
+			selectFrame: {
+				backgroundColor: Colors.primary_reversed,
+			},
+		}
 	}
 
 	genChartProps() {

--- a/src/mobX/states/UIStates/RightsSplitsPages/SplitPageState.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/SplitPageState.js
@@ -1,33 +1,43 @@
 import { action, computed, observable } from "mobx"
-import { Colors } from "../../../../theme"
+import { Colors, Metrics } from "../../../../theme"
+import { capValueWithinRange } from "../../../../utils/utils"
 
+export const CHART_MAX_SIZE = 384
+export const CHART_WINDOW_RATIO = 0.45
 /**
  *	Base class for splits pages. Splits UI
  *	states derive from it
  **/
 export default class SplitPageState {
-	@action init(domainState, pageTitle) {
-		this.domainState = domainState
-		this.pageTitle = pageTitle
-	}
-
 	constructor(logo) {
 		this.logo = logo
 	}
-	@observable domainState
 	pageTitle
 	progress
 	logo
-	@observable chartSize = 0
-	@computed get shares() {
-		return this.domainState.sharesValues
-	}
-
 	shareColors = Object.values(Colors.secondaries)
-
+	@observable domainState
+	@observable _chartSize = 0
 	colorByIndex(index) {
 		return this.shareColors[index % this.shareColors.length]
 	}
+
+	getStyles = (windowWidth) => ({
+		spacer:
+			windowWidth >= 1200
+				? {
+						width: 3 * Metrics.spacing.group,
+						height: 3 * Metrics.spacing.group,
+				  }
+				: {
+						width: Metrics.spacing.component,
+						height: Metrics.spacing.component,
+				  },
+		chart: {
+			position: "sticky",
+			top: Metrics.spacing.component,
+		},
+	})
 
 	sharesToChartData(shares = null) {
 		shares = shares ? shares : this.shares
@@ -47,7 +57,24 @@ export default class SplitPageState {
 		}
 	}
 
+	set chartSize(size) {
+		this._chartSize = capValueWithinRange(size, [0, CHART_MAX_SIZE])
+	}
+
+	@action init(domainState, pageTitle) {
+		this.domainState = domainState
+		this.pageTitle = pageTitle
+	}
+
+	@computed get shares() {
+		return this.domainState.sharesValues
+	}
+
 	@computed get sharesTotal() {
 		return this.shares.length
+	}
+
+	@computed get chartSize() {
+		return this._chartSize
 	}
 }

--- a/src/pages/workpieces/rights-splits/copyright.js
+++ b/src/pages/workpieces/rights-splits/copyright.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { View } from "react-native"
 import { Column, Row } from "../../../layout"
 import { Text, Heading, Paragraph } from "../../../text"
@@ -25,12 +25,19 @@ import Slider from "../../../widgets/slider"
 import { runInAction } from "mobx"
 import PercentageInput from "../../../forms/percentage"
 import { useSplitsPagesState } from "../../../mobX/hooks"
+import { CHART_WINDOW_RATIO } from "../../../mobX/states/UIStates/RightsSplitsPages/SplitPageState"
 
 const CopyrightForm = observer(() => {
 	const copyrightSplit = useRightsSplits("copyright")
 	const pageState = useSplitsPagesState("copyright")
 	const { sharesData, sharesTotal } = pageState
 	const { t } = useTranslation("rightsSplits")
+	const [styles, setStyles] = useState({})
+
+	useEffect(() => {
+		setStyles(pageState.getStyles(window.outerWidth))
+	}, [window.outerWidth])
+
 	function addShareHolder(id) {
 		if (id && !copyrightSplit.shareHolders.has(id)) {
 			copyrightSplit.addRightHolder(id, initData)
@@ -119,7 +126,11 @@ const CopyrightForm = observer(() => {
 	}
 
 	return (
-		<Row>
+		<Row
+			onLayout={(e) =>
+				(pageState.chartSize = e.nativeEvent.layout.width * CHART_WINDOW_RATIO)
+			}
+		>
 			<Column of="section" flex={1}>
 				<Column of="group">
 					<Row of="component">
@@ -153,24 +164,19 @@ const CopyrightForm = observer(() => {
 					</Column>
 				</Column>
 			</Column>
-			<View
-				style={{
-					width: 3 * Metrics.spacing.group,
-					height: 3 * Metrics.spacing.group,
-				}}
-			/>
-			<Column
-				flex={1}
-				align="center"
-				onLayout={(e) =>
-					runInAction(() => (pageState.chartSize = e.nativeEvent.layout.width))
-				}
-			>
-				{sharesData.length > 0 && copyrightSplit.mode === "roles" && (
-					<DualSplitChart {...pageState.genChartProps(copyrightSplit.mode)} />
-				)}
-				{sharesData.length > 0 && copyrightSplit.mode !== "roles" && (
-					<SplitChart {...pageState.genChartProps(copyrightSplit.mode)} />
+			<View style={styles.spacer} />
+			<Column>
+				{sharesData.length > 0 && (
+					<View style={styles.chart}>
+						{copyrightSplit.mode === "roles" && (
+							<DualSplitChart
+								{...pageState.genChartProps(copyrightSplit.mode)}
+							/>
+						)}
+						{copyrightSplit.mode !== "roles" && (
+							<SplitChart {...pageState.genChartProps(copyrightSplit.mode)} />
+						)}
+					</View>
 				)}
 			</Column>
 		</Row>

--- a/src/pages/workpieces/rights-splits/performance.js
+++ b/src/pages/workpieces/rights-splits/performance.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import { Column, Row } from "../../../layout"
 import { Text, Heading, Paragraph } from "../../../text"
 import { useTranslation } from "react-i18next"
@@ -15,24 +15,18 @@ import { useSplitsPagesState } from "../../../mobX/hooks"
 import { initData } from "../../../mobX/models/workpieces/rights-splits/PerformanceSplitModel"
 import ProgressBar from "../../../widgets/progress-bar"
 import { formatPercentage } from "../../../utils/utils"
-import { StyleSheet } from "react-native"
 import { runInAction } from "mobx"
-
-const Styles = StyleSheet.create({
-	checkboxesContainer: {
-		borderLeftWidth: 2,
-		borderLeftColor: Colors.stroke,
-		paddingLeft: Metrics.spacing.component,
-	},
-	selectFrame: {
-		backgroundColor: Colors.primary_reversed,
-	},
-})
+import { CHART_WINDOW_RATIO } from "../../../mobX/states/UIStates/RightsSplitsPages/SplitPageState"
 
 const PerformanceForm = observer(() => {
 	const performanceSplit = useRightsSplits("performance")
 	const pageState = useSplitsPagesState().performance
 	const { t } = useTranslation("rightsSplits")
+	const [styles, setStyles] = useState({})
+
+	useEffect(() => {
+		setStyles(pageState.getStyles(window.outerWidth))
+	}, [window.outerWidth])
 
 	function addShareHolder(id) {
 		if (id && !performanceSplit.shareHolders.has(id)) {
@@ -73,7 +67,7 @@ const PerformanceForm = observer(() => {
 					options={genSelectOptions()}
 					value={share.status}
 					onChange={(value) => performanceSplit.setShareStatus(share.id, value)}
-					style={Styles.selectFrame}
+					style={styles.selectFrame}
 				/>
 				<CheckBoxGroup
 					selection={share.roles}
@@ -81,7 +75,7 @@ const PerformanceForm = observer(() => {
 						performanceSplit.updateShareField(share.id, "roles", roles)
 					}
 				>
-					<Row style={Styles.checkboxesContainer}>
+					<Row style={styles.checkboxesContainer}>
 						<Column of="component">
 							<CheckBoxGroupButton value="singer" label={t("roles.singer")} />
 							<CheckBoxGroupButton
@@ -105,7 +99,11 @@ const PerformanceForm = observer(() => {
 	}
 
 	return (
-		<Row>
+		<Row
+			onLayout={(e) =>
+				(pageState.chartSize = e.nativeEvent.layout.width * CHART_WINDOW_RATIO)
+			}
+		>
 			<Column of="section" flex={1}>
 				<Column of="group">
 					<Row of="component">
@@ -127,20 +125,13 @@ const PerformanceForm = observer(() => {
 					/>
 				</Column>
 			</Column>
-			<View
-				style={{
-					width: 3 * Metrics.spacing.group,
-					height: 3 * Metrics.spacing.group,
-				}}
-			/>
-			<Column
-				flex={1}
-				align="center"
-				onLayout={(e) =>
-					runInAction(() => (pageState.chartSize = e.nativeEvent.layout.width))
-				}
-			>
-				{performanceSplit.mode && <SplitChart {...pageState.genChartProps()} />}
+			<View style={styles.spacer} />
+			<Column>
+				{performanceSplit.mode && (
+					<View style={styles.chart}>
+						<SplitChart {...pageState.genChartProps()} />
+					</View>
+				)}
 			</Column>
 		</Row>
 	)

--- a/src/pages/workpieces/rights-splits/recording.js
+++ b/src/pages/workpieces/rights-splits/recording.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import { Column, Row } from "../../../layout"
 import { Text, Heading, Paragraph } from "../../../text"
 import { useTranslation } from "react-i18next"
@@ -23,12 +23,18 @@ import { PercentageInput } from "../../../forms/percentage"
 import ProgressBar from "../../../widgets/progress-bar"
 import { formatPercentage } from "../../../utils/utils"
 import { runInAction } from "mobx"
+import { CHART_WINDOW_RATIO } from "../../../mobX/states/UIStates/RightsSplitsPages/SplitPageState"
 
 const RecordingForm = observer(() => {
 	const recordingSplit = useRightsSplits("recording")
 	const pageState = useSplitsPagesState("copyright")
 	const { sharesData, sharesTotal } = pageState
 	const { t } = useTranslation("rightsSplits")
+	const [styles, setStyles] = useState({})
+
+	useEffect(() => {
+		setStyles(pageState.getStyles(window.outerWidth))
+	}, [window.outerWidth])
 
 	function addShareHolder(id) {
 		if (id && !recordingSplit.shareHolders.has(id)) {
@@ -119,7 +125,11 @@ const RecordingForm = observer(() => {
 	}
 
 	return (
-		<Row>
+		<Row
+			onLayout={(e) =>
+				(pageState.chartSize = e.nativeEvent.layout.width * CHART_WINDOW_RATIO)
+			}
+		>
 			<Column of="section" flex={1}>
 				<Column of="group">
 					<Row of="component">
@@ -152,20 +162,11 @@ const RecordingForm = observer(() => {
 					</Column>
 				</Column>
 			</Column>
-			<View
-				style={{
-					width: 3 * Metrics.spacing.group,
-					height: 3 * Metrics.spacing.group,
-				}}
-			/>
-			<Column
-				flex={1}
-				align="center"
-				onLayout={(e) =>
-					runInAction(() => (pageState.chartSize = e.nativeEvent.layout.width))
-				}
-			>
-				<SplitChart {...pageState.genChartProps()} />
+			<View style={styles.spacer} />
+			<Column>
+				<View style={styles.chart}>
+					<SplitChart {...pageState.genChartProps()} />
+				</View>
 			</Column>
 		</Row>
 	)

--- a/src/smartsplit/components/add-collaborator-dropdown.js
+++ b/src/smartsplit/components/add-collaborator-dropdown.js
@@ -29,7 +29,7 @@ const AddCollaboratorDropdown = observer(({ onSelect, ...nextProps }) => {
 		<>
 			<Autocomplete
 				icon={PlusCircle}
-				placeholder={t("rightSplits:dropdowns.addCollab")}
+				placeholder={t("forms:labels.dropdowns.addCollaborator")}
 				search={search}
 				onSearchChange={setSearch}
 				{...nextProps}


### PR DESCRIPTION
* Split charts now have a max width: 464dp (as specified in Figma)
* Split pages layout: Responsive spacer between the two main columns
* Pie chart are sticky in split pages