### PR TITLE
1119 - Copyright split middleware implementation

### DIFF
--- a/src/mobX/models/workpieces/rights-splits/CopyrightSplitModel.js
+++ b/src/mobX/models/workpieces/rights-splits/CopyrightSplitModel.js
@@ -15,7 +15,7 @@ export default class CopyrightSplitModel extends RightSplitModel {
  **/
 export const initData = {
 	shares: 1,
-	roles: [],
+	roles: ["author", "composer"],
 	comment: "",
 	vote: "undecided",
 }

--- a/src/mobX/models/workpieces/rights-splits/RightSplitModel.js
+++ b/src/mobX/models/workpieces/rights-splits/RightSplitModel.js
@@ -6,9 +6,9 @@ import BaseModel from "../../../BaseModel"
 export default class RightSplitModel extends BaseModel {
 	constructor(id) {
 		super()
-		this.shareHolderId = id
+		this.shareholderId = id
 	}
 	toJS() {
-		return { shareHolderId: this.shareHolderId, ...super.toJS() }
+		return { shareholderId: this.shareholderId, ...super.toJS() }
 	}
 }

--- a/src/mobX/states/UIStates/RightsSplitsPages/CopyrightSplit.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/CopyrightSplit.js
@@ -37,7 +37,7 @@ export default class CopyrightSplit extends SplitPageState {
 				percent = 0
 			}
 			return {
-				id: share.shareHolderId,
+				id: share.shareholderId,
 				shares: share.shares,
 				roles: share.roles,
 				percent: percent,
@@ -45,19 +45,28 @@ export default class CopyrightSplit extends SplitPageState {
 		})
 	}
 
+	isMixerDisabled(roles) {
+		return !this.domainState.composerChosen && !roles.includes("mixer")
+	}
+
+	isAdapterDisabled(roles) {
+		return !this.domainState.authorChosen && !roles.includes("adapter")
+	}
+
 	genChartProps(mode) {
 		if (mode === "roles") {
 			return {
 				dataLeft: this.sharesToChartData(
-					this.shares.filter((share) => share.roles.includes("author"))
+					this.domainState.lyricsContributors.map((contrib) => ({
+						...contrib,
+						shares: 1,
+					}))
 				),
 				dataRight: this.sharesToChartData(
-					this.shares.filter(
-						(share) =>
-							share.roles.includes("composer") ||
-							share.roles.includes("mixer") ||
-							share.roles.includes("adapter")
-					)
+					this.domainState.musicContributors.map((contrib) => ({
+						...contrib,
+						shares: contrib.weighting,
+					}))
 				),
 				size: this.chartSize,
 				logo: this.logo,

--- a/src/mobX/states/UIStates/RightsSplitsPages/PerformanceSplit.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/PerformanceSplit.js
@@ -25,7 +25,7 @@ export default class PerformanceSplit extends SplitPageState {
 				percent = 0
 			}
 			return {
-				id: share.shareHolderId,
+				id: share.shareholderId,
 				shares: share.shares,
 				roles: share.roles,
 				status: share.status,

--- a/src/mobX/states/UIStates/RightsSplitsPages/RecordingSplit.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/RecordingSplit.js
@@ -23,7 +23,7 @@ export default class RecordingSplit extends SplitPageState {
 				percent = 0
 			}
 			return {
-				id: share.shareHolderId,
+				id: share.shareholderId,
 				shares: share.shares,
 				function: share.function,
 				percent: percent,

--- a/src/mobX/states/UIStates/RightsSplitsPages/SplitPageState.js
+++ b/src/mobX/states/UIStates/RightsSplitsPages/SplitPageState.js
@@ -46,8 +46,8 @@ export default class SplitPageState {
 		return shares
 			.filter((share) => share.shares)
 			.map((share, i) => ({
-				key: share.shareHolderId,
-				name: share.shareHolderId,
+				key: share.shareholderId,
+				name: share.shareholderId,
 				share: share.shares,
 				color: this.colorByIndex(i),
 			}))

--- a/src/mobX/states/WorkpieceStates/RightsSplits.js
+++ b/src/mobX/states/WorkpieceStates/RightsSplits.js
@@ -52,9 +52,9 @@ export default class RightsSplits {
 		// Observe splits shareholders and set hasChanged to
 		// true on first change
 		this._disposers = [
-			this.copyright.shareHolders.observe(this._toggleHasChanged),
-			// this.performance.shareHolders.observe(this._toggleHasChanged),
-			// this.recording.shareHolders.observe(this._toggleHasChanged),
+			this.copyright.shareholders.observe(this._toggleHasChanged),
+			// this.performance.shareholders.observe(this._toggleHasChanged),
+			// this.recording.shareholders.observe(this._toggleHasChanged),
 		]
 	}
 

--- a/src/mobX/states/WorkpieceStates/SplitStates/CopyrightSplit.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/CopyrightSplit.js
@@ -1,52 +1,121 @@
 import SplitState from "./SplitState"
-import CopyrightSplitModel from "../../../models/workpieces/rights-splits/CopyrightSplitModel"
-import { action, observable, reaction } from "mobx"
+import CopyrightSplitModel, {
+	initData,
+} from "../../../models/workpieces/rights-splits/CopyrightSplitModel"
+import { action, computed, observable, reaction } from "mobx"
 
 /**
  *	Copyright split domain state derived from SplitState.
- *	Contains manual mode middleware logic
+ *	Contains modes (equal, roles, manual) middleware logic
  **/
 export default class CopyrightSplit extends SplitState {
 	constructor(shares) {
-		super(shares, CopyrightSplitModel)
-		/**
-		 * reaction that performs roles checking upon
-		 * mode change to or from "equal"
-		 **/
+		super(shares, CopyrightSplitModel, initData)
 		reaction(
 			() => this.mode,
-			(mode) => {
-				if (mode === "equal" && !this.equalModeInitiated) {
-					this.initEqualMode()
-				} else {
-					this.equalModeInitiated = false
-				}
-			},
-			{ fireImmediately: true }
-		)
-
-		/**
-		 * Reaction that resets this.equalModeInitiated when
-		 * adding or removing a shareholder
-		 */
-		reaction(
-			() => this.shareHolders.keys(),
 			() => {
-				if (this.mode === "equal") {
-					this.initEqualMode()
+				switch (this.mode) {
+					case "equal":
+						this.computeEqualMode()
+						break
+					case "roles":
+						this.computeRolesMode()
+						break
 				}
 			}
 		)
 	}
-
-	@observable mode = "equal"
-	@observable equalModeInitiated = false
-
-	@action initEqualMode() {
-		this.equalModeInitiated = true
-		this.shareHolders.forEach((share, _) => {
-			!share.roles.includes("author") && share.roles.push("author")
-			!share.roles.includes("composer") && share.roles.push("composer")
+	@action computeEqualMode() {
+		this.sharesValues.forEach((share) => {
+			this.updateShareField(share.shareholderId, "shares", 1)
 		})
+	}
+
+	@action computeRolesMode() {
+		this.sharesValues.forEach((share) => {
+			const musicContribNb = this.musicContributors.reduce(
+				(n, current) => n + current.weighting,
+				0
+			)
+			const lyricsContribNb = this.lyricsContributors.length
+			let score = 0
+			if (
+				this.lyricsContributors.filter(
+					(contrib) => contrib.shareholderId === share.shareholderId
+				).length > 0
+			) {
+				score += (0.5 * this.shareholders.size) / lyricsContribNb
+			}
+
+			this.musicContributors.forEach((contrib) => {
+				if (contrib.shareholderId === share.shareholderId) {
+					score +=
+						(0.5 * contrib.weighting * this.shareholders.size) / musicContribNb
+				}
+			})
+			this.updateShareField(share.shareholderId, "shares", score)
+		})
+	}
+	@observable mode = "equal"
+
+	/**
+	 *	Id List of lyrics contributors
+	 *	Requires shareholder to have "composer"
+	 *	and/or "author" role(s)
+	 *	return Array<shareData>
+	 **/
+	@computed get lyricsContributors() {
+		const isLyricsContrib = (roles) =>
+			roles.includes("author") || roles.includes("adapter")
+		return this.sharesValues.filter((share) => isLyricsContrib(share.roles))
+	}
+
+	/**
+	*	Id List of music contributors
+	*	Each composer and mixer are considered 
+	*	contributor. So an id can be twice in the
+	*	list.
+
+	*	return Array<{...shareData, weighting}>
+	**/
+	@computed get musicContributors() {
+		const isMusicContrib = (roles) =>
+			roles.includes("composer") || roles.includes("mixer")
+		const contribs = this.sharesValues.filter((share) =>
+			isMusicContrib(share.roles)
+		)
+		const list = []
+		contribs.forEach((contrib) => {
+			contrib.weighting = 0
+			if (contrib.roles.includes("composer")) {
+				contrib.weighting += 1
+			}
+			if (contrib.roles.includes("mixer")) {
+				contrib.weighting += 1
+			}
+			list.push(contrib)
+		})
+		return list
+	}
+
+	@computed get composerChosen() {
+		return (
+			this.sharesValues.filter((share) => share.roles.includes("composer"))
+				.length > 0
+		)
+	}
+
+	@computed get authorChosen() {
+		return (
+			this.sharesValues.filter((share) => share.roles.includes("author"))
+				.length > 0
+		)
+	}
+
+	@action setRoles(id, roles) {
+		this.updateShareField(id, "roles", roles)
+		if (this.mode === "roles") {
+			this.computeRolesMode()
+		}
 	}
 }

--- a/src/mobX/states/WorkpieceStates/SplitStates/PerformanceSplit.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/PerformanceSplit.js
@@ -1,5 +1,7 @@
 import SplitState from "./SplitState"
-import PerformanceSplitModel from "../../../models/workpieces/rights-splits/PerformanceSplitModel"
+import PerformanceSplitModel, {
+	initData,
+} from "../../../models/workpieces/rights-splits/PerformanceSplitModel"
 import { action, computed, reaction } from "mobx"
 
 /**
@@ -8,9 +10,9 @@ import { action, computed, reaction } from "mobx"
  **/
 export default class PerformanceSplit extends SplitState {
 	constructor(shares) {
-		super(shares, PerformanceSplitModel)
+		super(shares, PerformanceSplitModel, initData)
 		reaction(
-			() => this.shareHolders.size,
+			() => this.shareholders.size,
 			() => this.updateShares()
 		)
 	}
@@ -59,11 +61,11 @@ export default class PerformanceSplit extends SplitState {
 		} else if (this.mode === "80-20") {
 			this.setShares(
 				this.majorShares,
-				(0.8 * this.shareHolders.size) / this.majorShares.length
+				(0.8 * this.shareholders.size) / this.majorShares.length
 			)
 			this.setShares(
 				this.minorShares,
-				(0.2 * this.shareHolders.size) / this.minorShares.length
+				(0.2 * this.shareholders.size) / this.minorShares.length
 			)
 		}
 	}

--- a/src/mobX/states/WorkpieceStates/SplitStates/RecordingSplit.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/RecordingSplit.js
@@ -1,5 +1,7 @@
 import SplitState from "./SplitState"
-import RecordingSplitModel from "../../../models/workpieces/rights-splits/RecordingSplitModel"
+import RecordingSplitModel, {
+	initData,
+} from "../../../models/workpieces/rights-splits/RecordingSplitModel"
 import { action, observable } from "mobx"
 
 /**
@@ -7,7 +9,7 @@ import { action, observable } from "mobx"
  **/
 export default class RecordingSplit extends SplitState {
 	constructor(shares) {
-		super(shares, RecordingSplitModel)
+		super(shares, RecordingSplitModel, initData)
 	}
 	functionValues = [
 		"producer",

--- a/src/mobX/states/WorkpieceStates/SplitStates/SplitState.js
+++ b/src/mobX/states/WorkpieceStates/SplitStates/SplitState.js
@@ -1,43 +1,48 @@
 import { action, computed, observable } from "mobx"
 
 /**
- *	Base class for domain state managing share holders
+ *	Base class for domain state managing shareholders
  **/
 export default class SplitState {
-	constructor(shares, shareModel) {
+	constructor(shares, shareModel, initShareData) {
 		this.shareModel = shareModel
-		if (shares) this.initShareHolders(shares)
+		this.initShareData = initShareData
+		if (shares) this.initShareholders(shares)
 	}
 
-	@observable shareHolders = new Map()
+	@observable shareholders = new Map()
 
 	/**
+	 *	Provide a data structure that makes easier
+	 *	to access and manipulate shares field values.
+	 * 	(hence shareS valueS, because each share has
+	 *	multiple values)
 	 * 	@return: Array<{Field.value}>
 	 **/
 	@computed get sharesValues() {
-		return [...this.shareHolders.values()].map((share) => share.toJS())
+		return [...this.shareholders.values()].map((share) => share.toJS())
 	}
 
 	@computed get shareTotal() {
 		return this.sharesValues.reduce((n, current) => n + current.shares, 0)
 	}
 
-	@action removeRightHolder(id) {
-		this.shareHolders.delete(id)
+	@action removeShareholder(id) {
+		this.shareholders.delete(id)
 	}
 
-	@action updateRightHolder(id, share) {
-		!share && this.shareHolders.get(id).reset()
-		!!share && this.shareHolders.get(id).setFields(share)
+	@action updateShareholder(id, share) {
+		!share && this.shareholders.get(id).reset()
+		!!share && this.shareholders.get(id).setFields(share)
 	}
 
-	@action addRightHolder(id, share = null) {
-		if (this.shareHolders.has(id)) {
-			throw new Error("Cannot add share: this user already has a share")
+	@action addShareholder(id, share = this.initShareData) {
+		if (this.shareholders.has(id)) {
+			return
 		}
 		const newShare = new this.shareModel(id)
 		newShare.init(share)
-		this.shareHolders.set(id, newShare)
+		this.shareholders.set(id, newShare)
 	}
 
 	/**
@@ -45,31 +50,31 @@ export default class SplitState {
 	 *	a shareholder directly from the UI
 	 **/
 	@action updateShareField(id, field, value) {
-		if (!this.shareHolders.get(id)) {
+		if (!this.shareholders.get(id)) {
 			return
 		}
-		this.shareHolders.get(id).setValue(field, value)
+		this.shareholders.get(id).setValue(field, value)
 	}
 
 	/**
-	 *	Populate this.shareHolders Map with the Array<ShareModel> argument
+	 *	Populate this.shareholders Map with the Array<ShareModel> argument
 	 **/
-	@action initShareHolders(shares) {
+	@action initShareholders(shares) {
 		shares.forEach((share) => {
 			this.addShare(share)
 		})
-		// const seenShareHolders = []
+		// const seenShareholders = []
 		// shares.forEach((share) => {
-		// 	seenShareHolders.push(share.shareHolderId)
-		// 	if (this.shareHolders.has(share.shareHolderId)) {
+		// 	seenShareholders.push(share.shareholderId)
+		// 	if (this.shareholders.has(share.shareholderId)) {
 		// 		this.updateShare(share)
 		// 	} else {
 		// 		this.addShare(share)
 		// 	}
 		// })
-		// this.shareHolders.forEach(
+		// this.shareholders.forEach(
 		// 	(value, key) =>
-		// 		seenShareHolders.indexOf(key) < 0 && this.removeRightHolder(key)
+		// 		seenShareholders.indexOf(key) < 0 && this.removeShareholder(key)
 		// )
 	}
 
@@ -80,10 +85,10 @@ export default class SplitState {
 	 */
 	@action applyDiffToShares(diff, shares) {
 		shares.forEach((share) => {
-			const id = share.shareHolderId
-			if (this.shareHolders.has(id)) {
-				const newValue = this.shareHolders.get(id).shares.value + diff
-				this.shareHolders.get(id).setValue("shares", newValue)
+			const id = share.shareholderId
+			if (this.shareholders.has(id)) {
+				const newValue = this.shareholders.get(id).shares.value + diff
+				this.shareholders.get(id).setValue("shares", newValue)
 			}
 		})
 	}
@@ -92,26 +97,26 @@ export default class SplitState {
 	 *	Update all shares if no shares array are provided.
 	 *	args:
 	 *	- Array<ShareValues>: ShareValues must
-	 *	be an object with a valid shareHolderId key
+	 *	be an object with a valid shareholderId key
 	 *	- value: Value to update shares with. Default
 	 *	to 1
 	 **/
 	@action setShares(shares = this.sharesValues, value = 1) {
 		shares.forEach((share) => {
-			this.shareHolders.get(share.shareHolderId).setValue("shares", value)
+			this.shareholders.get(share.shareholderId).setValue("shares", value)
 		})
 	}
 
 	addShare(share) {
-		return this.addRightHolder(share.shareHolderId, share)
+		return this.addShareholder(share.shareholderId, share)
 	}
 
 	updateShare(share) {
-		return this.updateRightHolder(share.shareHolderId, share)
+		return this.updateShareholder(share.shareholderId, share)
 	}
 
 	removeShare(share) {
-		return this.removeRightHolder(share.shareHolderId)
+		return this.removeShareholder(share.shareholderId)
 	}
 
 	/**
@@ -119,16 +124,16 @@ export default class SplitState {
 	 *	update the other shareholders shares on an inverse pro rata basis
 	 **/
 	@action updateSharesProRata(id, value) {
-		if (!this.shareHolders.has(id)) {
+		if (!this.shareholders.has(id)) {
 			throw new Error(`Error: share holder ${id} not found`)
 		}
 		// Difference between actual share and value to apply
-		// console.log("UPDATE SHARE", this.shareHolders.get(id))
+		// console.log("UPDATE SHARE", this.shareholders.get(id))
 
-		const diff = value - this.shareHolders.get(id).shares.value
+		const diff = value - this.shareholders.get(id).shares.value
 		// Select other candidate shares
-		const sortedShares = [...this.shareHolders.values()]
-			.filter((share) => share.shareHolderId !== id)
+		const sortedShares = [...this.shareholders.values()]
+			.filter((share) => share.shareholderId !== id)
 			.sort((a, b) => a.shares.value - b.shares.value)
 
 		// If diff < 0, we subtract a portion from the shareholder and then
@@ -168,6 +173,6 @@ export default class SplitState {
 			}
 		}
 
-		this.shareHolders.get(id).setValue("shares", value)
+		this.shareholders.get(id).setValue("shares", value)
 	}
 }

--- a/src/pages/workpieces/rights-splits/copyright.js
+++ b/src/pages/workpieces/rights-splits/copyright.js
@@ -18,7 +18,6 @@ import {
 import { useTranslation } from "react-i18next"
 import { observer } from "mobx-react"
 import { useRightsSplits } from "../context"
-import { initData } from "../../../mobX/models/workpieces/rights-splits/CopyrightSplitModel"
 import ProgressBar from "../../../widgets/progress-bar"
 import { formatPercentage } from "../../../utils/utils"
 import Slider from "../../../widgets/slider"
@@ -38,49 +37,45 @@ const CopyrightForm = observer(() => {
 		setStyles(pageState.getStyles(window.outerWidth))
 	}, [window.outerWidth])
 
-	function addShareHolder(id) {
-		if (id && !copyrightSplit.shareHolders.has(id)) {
-			copyrightSplit.addRightHolder(id, initData)
-		}
-	}
 	//FOR TESTING PURPOSE
 	// React.useEffect(() => {
-	// 	addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
-	// 	addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
+	// 	copyrightSplit.addShareholder("235556b5-3bbb-4c90-9411-4468d873969b")
+	// 	copyrightSplit.addShareholder("c84d5b32-25ee-48df-9651-4584b4b78f28")
 	// }, [])
 
 	function renderShareCards() {
 		return sharesData.map((share, i) => (
 			<ShareCard
 				key={share.id}
-				shareHolderId={share.id}
+				shareholderId={share.id}
 				color={pageState.colorByIndex(i)}
 				sharePercent={share.percent}
-				onClose={() => copyrightSplit.removeRightHolder(share.id)}
+				onClose={() => copyrightSplit.removeShareholder(share.id)}
 				manual={copyrightSplit.mode === "manual"}
 			>
 				<CheckBoxGroup
 					selection={share.roles}
-					onChange={(roles) =>
-						copyrightSplit.updateShareField(share.id, "roles", roles)
-					}
+					onChange={(roles) => copyrightSplit.setRoles(share.id, roles)}
 				>
 					<Row>
 						<Column flex={1} of="component">
+							<CheckBoxGroupButton value="author" label={t("roles.author")} />
 							<CheckBoxGroupButton
-								value="author"
-								label={t("roles.author")}
-								disabled={copyrightSplit.mode === "equal"}
+								value="adapter"
+								label={t("roles.adapter")}
+								disabled={pageState.isAdapterDisabled(share.roles)}
 							/>
-							<CheckBoxGroupButton value="adapter" label={t("roles.adapter")} />
 						</Column>
 						<Column flex={1} of="component">
 							<CheckBoxGroupButton
 								value="composer"
 								label={t("roles.composer")}
-								disabled={copyrightSplit.mode === "equal"}
 							/>
-							<CheckBoxGroupButton value="mixer" label={t("roles.mixer")} />
+							<CheckBoxGroupButton
+								value="mixer"
+								label={t("roles.mixer")}
+								disabled={pageState.isMixerDisabled(share.roles)}
+							/>
 						</Column>
 					</Row>
 				</CheckBoxGroup>
@@ -158,7 +153,7 @@ const CopyrightForm = observer(() => {
 					<Column of="component">
 						{renderShareCards()}
 						<AddCollaboratorDropdown
-							onSelect={addShareHolder}
+							onSelect={(id) => copyrightSplit.addShareholder(id)}
 							placeholder={t("addCollab")}
 						/>
 					</Column>

--- a/src/pages/workpieces/rights-splits/performance.js
+++ b/src/pages/workpieces/rights-splits/performance.js
@@ -12,7 +12,7 @@ import SplitChart from "../../../smartsplit/components/split-chart"
 import { observer } from "mobx-react"
 import { useRightsSplits } from "../context"
 import { useSplitsPagesState } from "../../../mobX/hooks"
-import { initData } from "../../../mobX/models/workpieces/rights-splits/PerformanceSplitModel"
+
 import ProgressBar from "../../../widgets/progress-bar"
 import { formatPercentage } from "../../../utils/utils"
 import { CHART_WINDOW_RATIO } from "../../../mobX/states/UIStates/RightsSplitsPages/SplitPageState"
@@ -27,16 +27,10 @@ const PerformanceForm = observer(() => {
 		setStyles(pageState.getStyles(window.outerWidth))
 	}, [window.outerWidth])
 
-	function addShareHolder(id) {
-		if (id && !performanceSplit.shareHolders.has(id)) {
-			performanceSplit.addRightHolder(id, initData)
-		}
-	}
-
 	//FOR TESTING PURPOSE
 	// React.useEffect(() => {
-	// 	addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
-	// 	addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
+	// 	performanceSplit.addShareholder("235556b5-3bbb-4c90-9411-4468d873969b")
+	// 	performanceSplit.addShareholder("c84d5b32-25ee-48df-9651-4584b4b78f28")
 	// }, [])
 	function genSelectOptions() {
 		return performanceSplit.statusValues.map((status) => {
@@ -56,10 +50,10 @@ const PerformanceForm = observer(() => {
 		return pageState.sharesData.map((share, i) => (
 			<ShareCard
 				key={share.id}
-				shareHolderId={share.id}
+				shareholderId={share.id}
 				color={pageState.colorByIndex(i)}
 				sharePercent={share.percent}
-				onClose={() => performanceSplit.removeRightHolder(share.id)}
+				onClose={() => performanceSplit.removeShareholder(share.id)}
 			>
 				<Select
 					placeholder={t("status")}
@@ -124,7 +118,7 @@ const PerformanceForm = observer(() => {
 				<Column of="component">
 					{renderShareCards()}
 					<AddCollaboratorDropdown
-						onSelect={addShareHolder}
+						onSelect={performanceSplit.addShareholder}
 						placeholder={t("addCollab")}
 					/>
 				</Column>

--- a/src/pages/workpieces/rights-splits/recording.js
+++ b/src/pages/workpieces/rights-splits/recording.js
@@ -12,7 +12,6 @@ import CircledP from "../../../svg/circled-p"
 import { observer } from "mobx-react"
 import { useRightsSplits } from "../context"
 import { useSplitsPagesState } from "../../../mobX/hooks"
-import { initData } from "../../../mobX/models/workpieces/rights-splits/RecordingSplitModel"
 import Slider from "../../../widgets/slider"
 import { PercentageInput } from "../../../forms/percentage"
 import ProgressBar from "../../../widgets/progress-bar"
@@ -31,16 +30,10 @@ const RecordingForm = observer(() => {
 		setStyles(pageState.getStyles(window.outerWidth))
 	}, [window.outerWidth])
 
-	function addShareHolder(id) {
-		if (id && !recordingSplit.shareHolders.has(id)) {
-			recordingSplit.addRightHolder(id, initData)
-		}
-	}
-
 	//FOR TESTING PURPOSE
 	// React.useEffect(() => {
-	// 	addShareHolder("235556b5-3bbb-4c90-9411-4468d873969b")
-	// 	addShareHolder("c84d5b32-25ee-48df-9651-4584b4b78f28")
+	// 	recordingSplit.addShareholder("235556b5-3bbb-4c90-9411-4468d873969b")
+	// 	recordingSplit.addShareholder("c84d5b32-25ee-48df-9651-4584b4b78f28")
 	// }, [])
 
 	function genSelectOptions() {
@@ -62,10 +55,10 @@ const RecordingForm = observer(() => {
 		return sharesData.map((share, i) => (
 			<ShareCard
 				key={share.id}
-				shareHolderId={share.id}
+				shareholderId={share.id}
 				color={pageState.colorByIndex(i)}
 				sharePercent={share.percent}
-				onClose={() => recordingSplit.removeRightHolder(share.id)}
+				onClose={() => recordingSplit.removeShareholder(share.id)}
 				manual={recordingSplit.mode === "manual"}
 			>
 				<Select
@@ -148,7 +141,7 @@ const RecordingForm = observer(() => {
 					<Column of="component">
 						{renderShareCards()}
 						<AddCollaboratorDropdown
-							onSelect={addShareHolder}
+							onSelect={recordingSplit.addShareholder}
 							placeholder={t("addCollab")}
 						/>
 					</Column>

--- a/src/smartsplit/components/share-card.js
+++ b/src/smartsplit/components/share-card.js
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
 })
 const ShareCard = observer(
 	({
-		shareHolderId,
+		shareholderId,
 		children,
 		actions,
 		error,
@@ -37,7 +37,7 @@ const ShareCard = observer(
 		...nextProps
 	}) => {
 		const { t } = useTranslation()
-		const user = useEntity(["users"], shareHolderId)
+		const user = useEntity(["users"], shareholderId)
 		const userData = toJS(user.data) || {}
 		const authUserData = toJS(useAuthUser().data)
 		const frameStyle = [CardStyles.frame, styles.frame]


### PR DESCRIPTION
* Split domain states refactor: addShareholder now use initShareData inside SplitState
* CopyrightSplit: Overriding SplitState.addShareholder to add specific
  fields in "equal" mode
* Copyright middleware implementation
* Connected copyright page UI to its stores